### PR TITLE
Shm region

### DIFF
--- a/include/buffer
+++ b/include/buffer
@@ -31,7 +31,7 @@
 #include "database.hpp"
 #include "threadlocaldata.hpp"
 #include "bufferdefs.hpp"
-
+#include "shared_seg.hpp"
 #include "buffer_base.hpp"
     
 
@@ -52,13 +52,6 @@ class buffer :
                public buffer_base
 
 {
-public:
-    /**
-     * the shared segment comes with a parameter that enables you
-     * to call an initialization function on the data segment before
-     * anybody can actually access it.
-     */
-     using init_func_t = std::function< void( void* ) >;
 private:
     static global_err_t gb_err;
 
@@ -145,7 +138,7 @@ private:
                               const ipc::channel_type   channel_type,
                               const ipc::direction_t    dir,
                               const std::size_t         additional_bytes = 0,
-                              ipc::buffer::init_func_t  f = nullptr);
+                              ipc::buffer::shm_seg::init_func_t  f = nullptr);
                                         
 public:
     
@@ -350,7 +343,7 @@ public:
     channel_id_t    add_shared_segment( ipc::thread_local_data *tls,
                                         const channel_id_t      channel_id,
                                         const std::size_t       n_bytes,
-                                        init_func_t             f );
+                                 ipc::buffer::shm_seg::init_func_t             f );
 
 
     /**
@@ -362,8 +355,9 @@ public:
      * @return valid pointer if no errors, nullptr if failure. 
      */
     static
-    void*           open_shared_segment( ipc::thread_local_data *tls,
-                                         const channel_id_t     channel_id );
+    ipc::tx_code           open_shared_segment( ipc::thread_local_data *tls_data,
+                                                const channel_id_t     channel_id,
+                                                void                   **data );
 
     /**
      * channel_has_data - return if the given CONSUMER channel in channel id, from the TLS block 

--- a/include/buffer
+++ b/include/buffer
@@ -24,6 +24,8 @@
 #include <cstdint>
 #include <string>
 #include <sstream>
+#include <functional>
+
 #include "genericnode.hpp"
 #include "indexbase.hpp"
 #include "database.hpp"
@@ -50,11 +52,16 @@ class buffer :
                public buffer_base
 
 {
+public:
+    /**
+     * the shared segment comes with a parameter that enables you
+     * to call an initialization function on the data segment before
+     * anybody can actually access it.
+     */
+     using init_func_t = std::function< void( void* ) >;
 private:
     static global_err_t gb_err;
 
-
-    
     /** 
      * set global block inc to be 1MiB, will allocate multiple 'x'
      * of this if the user requests large blocks.
@@ -136,9 +143,13 @@ private:
     channel_id_t add_channel( ipc::thread_local_data    *tls, 
                               const channel_id_t        channel_id,
                               const ipc::channel_type   channel_type,
-                              const ipc::direction_t    dir );
+                              const ipc::direction_t    dir,
+                              const std::size_t         additional_bytes = 0,
+                              ipc::buffer::init_func_t  f = nullptr);
                                         
 public:
+    
+
     buffer();
     ~buffer() = default;
     
@@ -221,11 +232,18 @@ public:
                                         void **record );
 
 
-
+    /**
+     * get_tls_structure - allocate a thread local structure (TLS) for each thread
+     * that will use the buffer. This must be done to use almost all of the 
+     * subsequent buffer functions. 
+     */
     static ipc::thread_local_data* get_tls_structure( ipc::buffer *buffer,
                                                       const ipc::thread_id_t thread_id );
 
-
+    /**
+     * opposite of get_tls_structure, close the tls structure that was once opened,
+     * also unlinks things allocated for this TLS (housekeeping). 
+     */
     static void close_tls_structure( ipc::thread_local_data *d );
 
     /**
@@ -315,7 +333,38 @@ public:
     channel_id_t add_spsc_lf_record_channel( ipc::thread_local_data *tls, 
                                              const channel_id_t channel_id,
                                              ipc::direction_t   dir );
-   
+    
+    
+    /**
+     * add_shared_segment - open a static block of memory between 
+     * multiple processes/threads. It is on the user to ensure that
+     * data is properly synchronized between this shared region. As
+     * an example, only one writer, multiple readers. 
+     * @param tls - TLS segment,
+     * @param channel_id - channel that you want the shared segment on
+     * @param n_bytes - unlike the record function this is fixed size,
+     * @return channel_id_t - should match the param channel, or err
+     * codes are returned, see record channel for description. 
+     */
+    static
+    channel_id_t    add_shared_segment( ipc::thread_local_data *tls,
+                                        const channel_id_t      channel_id,
+                                        const std::size_t       n_bytes,
+                                        init_func_t             f );
+
+
+    /**
+     * open the block of memory associated with a channel_id and shared
+     * segment. You can use the "record_size" functions to get the total
+     * size if needed. 
+     * @param tls - TLS segment
+     * @param channel_id - channel that the shared segment is on.
+     * @return valid pointer if no errors, nullptr if failure. 
+     */
+    static
+    void*           open_shared_segment( ipc::thread_local_data *tls,
+                                         const channel_id_t     channel_id );
+
     /**
      * channel_has_data - return if the given CONSUMER channel in channel id, from the TLS block 
      * data has data on the channel. Returns at least 1  if the channel has data. For
@@ -331,20 +380,46 @@ public:
     static
     std::size_t channel_has_data(   ipc::thread_local_data *data, 
                                     const channel_id_t channel_id );
-
+    
+    /**
+     * returns the full allocated extend of the record, e.g., if the producer
+     * allocated 256B, the actual record size is not this but whatever the 
+     * underlying allocation block size. That alloc block size is what 
+     * is returned here, well, however many blocks are contained in this
+     * record. 
+     * @param data - TLS segment
+     * @param ptr  - ptr to cehck the record size, must have been allocated from 
+     * our buffer. 
+     * @return size of the object. 
+     */
     static
     std::size_t get_record_size( ipc::thread_local_data *data, void *ptr );
 
-
+    
+    /**
+     * returns true if the indicated channel has currently attached producers. 
+     * @param tls - TLS segment 
+     * @param channel - channel to return the value on. 
+     * @return bool - true if producers exist on the channel, false otherwise. 
+     */
     static
     bool
     channel_has_producers( ipc::thread_local_data *tls, const ipc::channel_id_t channel );
 
+    /**
+     * has_active_channels - returns true if there are any active channels
+     * in the buffer used by the TLS indicated. 
+     * @param tls - TLS segment
+     * @param bool - true if any active channels. 
+     */
     static
     bool
     has_active_channels( ipc::thread_local_data *tls );
 
-
+    /**
+     * returns a channel_map_t object filled with the currently active
+     * channels, these channels are not guaranteed to still be active. 
+     */
     static
     ipc::channel_map_t
     get_channel_list( ipc::thread_local_data *tls );
@@ -362,6 +437,7 @@ public:
     /**
      * remove_channel - remove channel with given ID assicoated with this tls
      * structure.
+     * NOTE: this works for all types of channels. 
      * @return bool - if channel found, if found it's refcount is decremented
      * if refcount is zero, channel is removed and deallocated to buffer.
      */

--- a/include/bufferdefs.hpp
+++ b/include/bufferdefs.hpp
@@ -87,6 +87,7 @@ namespace ipc
     {
         spsc_record,
         mpmc_record,
+        shared,
         atomic,
         spsc_data,
         mpmc_data,
@@ -99,6 +100,7 @@ namespace ipc
        {{
              "spsc_record",
              "mpmc_record",
+             "shared",
              "atomic",
              "spsc_data",
              "mpmc_data",

--- a/include/ch_meta_all.hpp
+++ b/include/ch_meta_all.hpp
@@ -37,7 +37,8 @@ struct alignas( L1D_CACHE_LINE_SIZE ) ch_meta_all
    
     ipc::refcnt_t       ref_count_prod                    = 0; 
     ipc::refcnt_t       ref_count_cons                    = 0; 
-    
+    ipc::refcnt_t       ref_count_shd                     = 0; 
+
     ipc::channel_type   type                              = ipc::spsc_record;
     ipc::sem::sem_key_t channel_semaphore                 = { 0 };
     /**

--- a/include/meta_info.hpp
+++ b/include/meta_info.hpp
@@ -28,6 +28,7 @@
 #include "lock_ll.hpp"
 #include "mpmc_lock_free.hpp"
 #include "spsc_lock_free.hpp"
+#include "shared_seg.hpp"
 #include "channelindex.hpp"
 #include "recordindex.hpp"
 
@@ -54,6 +55,9 @@ public:
     using spsc_lock_free    = ipc::spsc_lock_free_queue< ipc::channel_info,
                                                          void,
                                                          translate_helper >;
+    using shm_seg           = ipc::shared_seg< ipc::channel_info /**reuse spsc**/, 
+                                               translate_helper >;
+    
     meta_info()     = default;
     ~meta_info()    = default;
 

--- a/include/shared_seg.hpp
+++ b/include/shared_seg.hpp
@@ -1,0 +1,82 @@
+/**
+ * shared_seg.hpp - this header doesn't do too much at the moment, 
+ * but wanted to make sure there is a sep. place to do shared mem
+ * initialization outside of just throwing it in one large cpp file
+ * that is buffer.cpp. 
+ *
+ * @author: Jonathan Beard
+ * @version: Wed Oct  6 05:37:14 2021
+ * 
+ * Copyright 2021 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SHARED_SEG_HPP
+#define SHARED_SEG_HPP  1
+#include <functional>
+#include "ch_meta_all.hpp"
+
+
+namespace ipc
+{
+template < class PARENTNODE, class TRANSLATE > class shared_seg
+{
+public:
+    using init_func_t = std::function< void( void* ) >;
+
+    shared_seg()  = delete;
+    ~shared_seg() = delete;
+    /**
+     * init - initialize shared segment, provide init func
+     * as optional for users to initialize the segment to 
+     * specific values before it's handed back to anyone.
+     */
+    static void init( void *buffer_base, 
+                      void *channel_base,
+                      void *seg_base, 
+                      init_func_t f = nullptr )
+    {
+        /** looks a bit odd given we're going to reuse the channel structure **/ 
+        auto *node = (PARENTNODE*)channel_base;
+        //get offset to add
+        const auto offset_to_add = 
+                TRANSLATE::calculate_block_offset( buffer_base,
+                                                   seg_base );
+        /** 
+         * set queue head entry to shared mem seg. Ultimately
+         * the reason we re-used the shm segment is we wanted
+         * to give the programmer a windowed or named shared mem
+         * region without having to set up sep. channels so, these
+         * can be "sub-channels" at some future point. 
+         */
+        node->spsc_q.entry[0] = offset_to_add;
+        if( f != nullptr ){ f( seg_base ); }
+        return;
+    }
+
+    static ipc::tx_code get_segment( PARENTNODE *channel, 
+                                     void **receive_node, 
+                                     void *buffer_base )
+    {
+        /** since we're reusing the spsc control structure, return head **/
+        const auto offset = 
+            channel->spsc_q.entry[0];
+        /** should always succeed **/
+        *receive_node = TRANSLATE::translate_block( buffer_base, 
+                                                    offset );
+        return( ipc::tx_success );
+    }
+};
+
+} /** end namespace ipc **/
+#endif /* END SHARED_SEG_HPP */

--- a/include/threadlocaldata.hpp
+++ b/include/threadlocaldata.hpp
@@ -96,10 +96,16 @@ struct thread_local_data
      */
     ipc::buffer *buffer = nullptr;
     
-
+    /**
+     * contains all channels, including ones that
+     * are shared segment channels. 
+     */
     std::map< ipc::channel_id_t,
               ipc::channel_info* >  channel_map;
     
+    /**
+     * does not contain shared segment channels. 
+     */
     std::map< ipc::channel_id_t, 
               ipc::local_allocation_info > channel_local_allocation;
 

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -22,6 +22,7 @@ set( TESTAPPS #list apps
         lf_spsc_node_insert_remove_twothreads
         multiChannelIteration
         record_size
+        shared_seg_two_process
         spsc_two_threads
         spsc_two_processes
         spsc_two_processes_has_data

--- a/testsuite/shared_seg_two_process.cpp
+++ b/testsuite/shared_seg_two_process.cpp
@@ -36,7 +36,7 @@ struct shm_seg
         real_ptr->value = -1;
     }
 
-    std::int64_t value = -1;
+    volatile std::int64_t value = -1;
 };
 
 

--- a/testsuite/shared_seg_two_process.cpp
+++ b/testsuite/shared_seg_two_process.cpp
@@ -1,0 +1,229 @@
+/**
+ * @author: Jonathan Beard
+ * @version: Fri Sep 12 10:28:33 2014
+ * 
+ * Copyright 2014 Jonathan Beard
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdlib>
+#include <typeinfo>
+#include <iostream>
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <buffer>
+
+
+struct shm_seg
+{
+    static void init( void *ptr )
+    {
+        auto *real_ptr = (shm_seg*)ptr;
+        real_ptr->value = -1;
+    }
+
+    std::int64_t value = -1;
+};
+
+
+/**
+ * Here's what's going to happen, producer will send data to 
+ * consumer, consumer will update shared segment, then the 
+ * producer will read it and move on to the next one. If all
+ * values are seen at the consumer then the test is passed,
+ * otherwise it fails. 
+ */
+
+using gate_t = std::atomic< int >;
+
+void producer(  const int count, 
+                const ipc::channel_id_t channel_id, 
+                ipc::buffer *buffer ) 
+{
+    const auto thread_id    = getpid();
+    auto *tls_producer      = ipc::buffer::get_tls_structure( buffer, thread_id );
+    std::cout << "beginning: " << 
+        ipc::meta_info::heap_t::get_current_free( &tls_producer->buffer->heap  ) << "\n";
+    if( ipc::buffer::add_spsc_lf_record_channel( tls_producer, 
+                                                 channel_id, 
+                                                 ipc::producer ) == ipc::channel_err )
+    {
+        std::cout << "channel error in producer\n";
+        assert( false );
+    }
+
+    if( ipc::buffer::add_shared_segment( tls_producer,
+                                         channel_id + 1 /** seg channel **/,
+                                         sizeof( shm_seg ),
+                                         shm_seg::init ) == ipc::channel_err )
+    {
+        std::cout << "channel error in producer\n";
+        assert( false );
+    }
+    
+    shm_seg *shared_seg = nullptr;
+    if( ipc::buffer::open_shared_segment( tls_producer, 
+                                          channel_id + 1, 
+                                          (void**)&shared_seg ) != ipc::tx_success )
+    {
+        std::cout << "failed to open shared segment\n";
+        assert( false );
+    }
+    for( int i( 0 ); i < count ; i++ )
+    {
+        int *output = 
+            (int*) ipc::buffer::allocate_record( tls_producer, 
+                                                 sizeof( int ), 
+                                                 channel_id );
+        *output = i;    
+        //send
+        while( ipc::buffer::send_record( tls_producer, 
+                                         channel_id, 
+                                         (void**)&output ) != ipc::tx_success );
+        //spin till shared seg value is equal to what we expect
+        while( shared_seg->value != i );
+    }
+    ipc::buffer::unlink_channels( tls_producer );
+    std::cout << "end producer: " << 
+        ipc::meta_info::heap_t::get_current_free( &tls_producer->buffer->heap  ) << "\n";
+    ipc::buffer::close_tls_structure( tls_producer );
+    return;
+}
+
+void consumer(  const int count, 
+                const ipc::channel_id_t channel_id, 
+                ipc::buffer *buffer ) 
+{
+    const auto thread_id    = getpid();
+    auto *tls_consumer      = ipc::buffer::get_tls_structure( buffer, 
+                                                              thread_id );
+
+    if( ipc::buffer::add_spsc_lf_record_channel( tls_consumer, 
+                                                 channel_id, 
+                                                 ipc::consumer ) == ipc::channel_err )
+    {
+        std::cout << "channel error in consumer\n";
+        return;
+    }
+    if( ipc::buffer::add_shared_segment( tls_consumer,
+                                         channel_id + 1 /** seg channel **/,
+                                         sizeof( shm_seg ),
+                                         shm_seg::init ) == ipc::channel_err )
+    {
+        std::cout << "channel error in consumer\n";
+        assert( false );
+    }
+
+    shm_seg *shared_seg = nullptr;
+    if( ipc::buffer::open_shared_segment( tls_consumer, 
+                                          channel_id + 1, 
+                                          (void**)&shared_seg ) != ipc::tx_success )
+    {
+        std::cout << "failed to open shared segment in consumer\n";
+        assert( false );
+    }
+    
+
+    void *record = nullptr;
+    auto count_tracker( 0 );
+    int value = ~0;
+    do
+    {
+        
+        while( ipc::buffer::receive_record( tls_consumer, 
+                                            channel_id, 
+                                            &record ) != ipc::tx_success );
+        value = *(int*)record;
+        shared_seg->value = value; 
+        ipc::buffer::free_record( tls_consumer, record );
+        
+        if( value != count_tracker)
+        {
+            std::cerr << "buffer failed async tests @ consumer, (" << 
+                value << ") vs (" << count_tracker << ")\n";
+            exit( EXIT_FAILURE );
+        }
+        count_tracker++;
+    }while( value != (count - 1) );
+    //just remove all channels for this tls block, we only have one
+    ipc::buffer::unlink_channels( tls_consumer );
+    std::cout << "end consumer: " << 
+        ipc::meta_info::heap_t::get_current_free( &tls_consumer->buffer->heap  ) << "\n";
+    ipc::buffer::close_tls_structure( tls_consumer );
+    return;
+}
+
+int main( int argc, char **argv )
+{
+    ipc::buffer::register_signal_handlers();
+
+    const auto channel_id   = 1;
+
+    //max count is 30 - 12 or (1<<18)
+    //this should be bigger than the buffer size, we wanna make 
+    //sure the allocator and everything else works. 
+    int count = (1 << 20 );
+    if( argc > 1 )
+    {
+        count = (1 << atoi( argv[ 1 ] ) );
+    }
+    bool is_producer( false );
+    auto child = fork();
+    switch( child )
+    {
+        case( 0 /** child **/ ):
+        {   
+            //consumer
+            is_producer = false;
+        }
+        break;
+        case( -1 /** error, back to parent **/ ):
+        {
+            exit( EXIT_FAILURE );
+        }
+        break;
+        default:
+        {
+            //producer
+            is_producer = true;
+        }
+    }
+    
+    auto *buffer = ipc::buffer::initialize( "thehandle"  );
+    if( is_producer )
+    {
+        producer(  count, 
+                   channel_id, 
+                   buffer );
+
+        //we'll make the producer the main
+        int status = 0;
+        waitpid( -1, &status, 0 );
+        ipc::buffer::destruct( buffer, "thehandle" );
+    }
+    else
+    {
+        consumer(  count, 
+                   channel_id, 
+                   buffer );
+        ipc::buffer::destruct( buffer, "thehandle", false );
+
+    }
+    //buffer shouldn't destruct completely till everybody 
+    //is done using it. 
+    return( EXIT_SUCCESS );
+}


### PR DESCRIPTION
Added static shared region support 

```cpp
    if( ipc::buffer::add_shared_segment( tls_producer,
                                         channel_id + 1 /** seg channel **/,
                                         sizeof( shm_seg ),
                                         shm_seg::init ) == ipc::channel_err )
    {
        std::cout << "channel error in producer\n";
        assert( false );
    }
```
```cpp
    shm_seg *shared_seg = nullptr;
    if( ipc::buffer::open_shared_segment( tls_producer, 
                                          channel_id + 1, 
                                          (void**)&shared_seg ) != ipc::tx_success )
    {
        std::cout << "failed to open shared segment\n";
        assert( false );
    }
```
